### PR TITLE
fix for package.json + api-doc template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.js
+++ b/index.js
@@ -752,7 +752,7 @@ function generateBaseApiDoc(existingFiles, apiDoc) {
     const version = getVersion(apiDoc);
 
     const baseApiDoc = Object.assign({}, apiDoc, {
-        paths: []
+        paths: {}
     });
 
     const relPath = `src/api/${version}/base-api-doc.yml`;

--- a/template/package.json
+++ b/template/package.json
@@ -5,7 +5,7 @@
     "main": "",
     "scripts": {
         "clean": "rm -rf ./build",
-        "build": "cp -r ./src ./build && babel ./src/ --out-dir ./build/",
+        "build": "cp -r ./src/ ./build && babel ./src/ --out-dir ./build/",
         "start": "node build/bin/www.js",
         "dev": "NODE_ENV=development babel-node $NODE_DEBUG_OPTION src/bin/www.js",
         "dev:watch": "NODE_ENV=development nodemon --exec npm run dev"


### PR DESCRIPTION
- copy only contents of `src/` to `build/` on build
- use empty object instead of array in `paths` 